### PR TITLE
add option to catch ambiguous union resolution

### DIFF
--- a/dacite/config.py
+++ b/dacite/config.py
@@ -9,3 +9,4 @@ class Config:
     forward_references: Optional[Dict[str, Any]] = None
     check_types: bool = True
     strict: bool = False
+    no_ambiguous_resolution: bool = False

--- a/dacite/exceptions.py
+++ b/dacite/exceptions.py
@@ -1,4 +1,4 @@
-from typing import Any, Type, Optional, Set
+from typing import Any, Type, Optional, Set, Dict
 
 
 def _name(type_: Type) -> str:
@@ -47,6 +47,18 @@ class UnionMatchError(WrongTypeError):
         return (
             f'can not match type "{_name(type(self.value))}" to any type '
             f'of "{self.field_path}" union: {_name(self.field_type)}'
+        )
+
+class AmbiguousResolutionError(DaciteError):
+    def __init__(self, resolutions: Dict) -> None:
+        super().__init__()
+        self.resolutions = resolutions
+
+    def __str__(self) -> str:
+        conflicting_types = ', '.join(f'{key}' for key in self.resolutions.keys())
+        return (
+            f'cannot choose between possible Union member resolutions:\n'
+            '{}'.format(conflicting_types)
         )
 
 

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -4,7 +4,13 @@ from typing import Optional, List, Union
 
 import pytest
 
-from dacite import from_dict, Config, ForwardReferenceError, UnexpectedDataError
+from dacite import (
+    from_dict,
+    Config,
+    ForwardReferenceError,
+    UnexpectedDataError,
+    AmbiguousResolutionError,
+)
 
 
 def test_from_dict_with_type_hooks():
@@ -142,3 +148,26 @@ def test_from_dict_with_strict():
         from_dict(X, {"s": "test", "i": 1}, Config(strict=True))
 
     assert str(exception_info.value) == 'can not match "i" to any data class field'
+
+
+def test_no_ambiguous_resolution():
+    @dataclass
+    class X:
+        i: int
+
+    @dataclass
+    class Y:
+        i: int
+
+    @dataclass
+    class Z:
+        u: Union[X, Y]
+
+    data = {
+        'u': {
+            'i': 0,
+        },
+    }
+
+    with pytest.raises(AmbiguousResolutionError):
+        result = from_dict(data_class=Z, data=data, config=Config(no_ambiguous_resolution=True))


### PR DESCRIPTION
Add a flag to raise an error if a dacite dataclass construction is being
performed on a datatype which can be resolved multiple ways.

I think we should make use of this for brine config parsing.

The error message is about as useful as any of Dacite's other ones. :P

Considering asking the Dacite maintainer if they'd like to review something similar.

I noticed that although this pull request is into our master branch, we're using the head of Ari's branch currently, so we'd actually want to make a branch which has both of our patches.